### PR TITLE
Allows to provide build-args to the Dockerfile build process

### DIFF
--- a/lib/cuber/commands/deploy.rb
+++ b/lib/cuber/commands/deploy.rb
@@ -66,6 +66,9 @@ module Cuber::Commands
       tag = "#{@options[:image]}:#{@options[:release]}"
       cmd = ['docker', 'build']
       cmd += ['--pull', '--no-cache'] if @options[:cache] == false
+      @options[:buildargs].each do |key, value|
+        cmd += ['--build-arg', "#{key}=#{value}"]
+      end
       cmd += ['--platform', 'linux/amd64', '--progress', 'plain', '-f', dockerfile, '-t', tag, '.']
       system(*cmd, chdir: '.cuber/repo') || abort('Cuber: docker build failed')
     end

--- a/lib/cuber/cuberfile_parser.rb
+++ b/lib/cuber/cuberfile_parser.rb
@@ -5,6 +5,7 @@ module Cuber
       @release = nil
       @repo = nil
       @buildpacks = nil
+      @buildargs = {}
       @dockerfile = nil
       @image = nil
       @cache = nil
@@ -42,6 +43,10 @@ module Cuber
 
     def dockerfile path
       @dockerfile = path
+    end
+
+    def buildarg key, value
+      @buildargs[key] = value
     end
 
     def image name

--- a/lib/cuber/cuberfile_validator.rb
+++ b/lib/cuber/cuberfile_validator.rb
@@ -12,6 +12,7 @@ module Cuber
       validate_repo
       validate_buildpacks
       validate_dockerfile
+      validate_buildargs
       validate_image
       validate_cache
       validate_dockerconfig
@@ -52,6 +53,13 @@ module Cuber
     def validate_dockerfile
       return unless @options[:dockerfile]
       @errors << 'dockerfile must be a file' unless File.exists? @options[:dockerfile]
+    end
+
+    def validate_buildargs
+      @options[:buildargs].each do |key, value|
+        @errors << "buildarg key must be present" if key.to_s.strip.empty?
+        @errors << "buildarg \"#{key}\" value must be present" if value.to_s.strip.empty?
+      end
     end
 
     def validate_image


### PR DESCRIPTION
I needed the ability to add build-args to the build process of the Dockerfile.

So I added it to the Cuberfile parser.

Example:
```ruby
app 'test'
repo '.'
dockerfile 'Dockerfile'
dockerconfig 'config/dockerconfig.json'
image 'my/image-name'
buildarg 'RAILS_ENV', 'stage'
buildarg 'VERSION', 'v1.2.3'
proc :web, 'bundle exec rails s'
```

Maybe you'll find the useful or have any requests for changes.

Thank you anyhow for this amazing gem. 😄 