### PR TITLE
Allows to define hostAliases for all pods

### DIFF
--- a/lib/cuber/cuberfile_parser.rb
+++ b/lib/cuber/cuberfile_parser.rb
@@ -15,6 +15,7 @@ module Cuber
       @cron = {}
       @secrets = {}
       @env = {}
+      @hostaliases = {}
       @lb = {}
       @ingress = nil
       @ssl = nil
@@ -74,6 +75,10 @@ module Cuber
 
     def env key, value, secret: false
       secret ? (@secrets[key] = value) : (@env[key] = value)
+    end
+
+    def hostalias ip, hostnames: []
+      @hostaliases[ip] = hostnames
     end
 
     def lb key, value

--- a/lib/cuber/cuberfile_validator.rb
+++ b/lib/cuber/cuberfile_validator.rb
@@ -103,6 +103,16 @@ module Cuber
       end
     end
 
+    def validate_hostalias
+      @options[:hostaliases].each do |ip, hostnames|
+        @errors << "hostalias \"#{ip}\" must be a valid ip address" if ip !~ /\A\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\z/
+        @errors << "hostalias \"#{ip}\" must define at least one hostname" if hostnames.empty?
+        hostnames.each do |hostname|
+          @errors << "hostalias \"#{ip}\" hostname \"#{hostname}\" can only include lowercase letters, digits, dots or dashes" if hostname !~ /\A[a-z0-9\-\.]+\z/
+        end
+      end
+    end
+
     def validate_lb
       @options[:lb].each do |key, value|
         @errors << "lb \"#{key}\" key can only include letters, digits, underscores, dashes, dots or slash" if key !~ /\A[a-zA-Z0-9_\-\.\/]+\z/

--- a/lib/cuber/templates/deployment.yml.erb
+++ b/lib/cuber/templates/deployment.yml.erb
@@ -80,6 +80,16 @@ spec:
         app.kubernetes.io/version: <%= @options[:release] %>
         app.kubernetes.io/managed-by: cuber
     spec:
+      <%- if @options[:hostaliases].any? -%>
+      hostAliases:
+      <%- @options[:hostaliases].each do |ip, hostnames| -%>
+      - ip: "<%= ip %>"
+        hostnames:
+        <%- hostnames.each do |hostname| -%>
+        - "<%= hostname %>"
+        <%- end -%>
+      <%- end -%>
+      <%- end -%>
       containers:
       - name: migration
         image: <%= @options[:image] %>:<%= @options[:release] %>
@@ -127,6 +137,16 @@ spec:
         app.kubernetes.io/managed-by: cuber
         app: <%= procname %>-proc
     spec:
+      <%- if @options[:hostaliases].any? -%>
+      hostAliases:
+      <%- @options[:hostaliases].each do |ip, hostnames| -%>
+      - ip: "<%= ip %>"
+        hostnames:
+        <%- hostnames.each do |hostname| -%>
+        - "<%= hostname %>"
+        <%- end -%>
+      <%- end -%>
+      <%- end -%>
       containers:
       - name: <%= procname %>-proc
         image: <%= @options[:image] %>:<%= @options[:release] %>
@@ -212,6 +232,16 @@ spec:
             app.kubernetes.io/version: <%= @options[:release] %>
             app.kubernetes.io/managed-by: cuber
         spec:
+          <%- if @options[:hostaliases].any? -%>
+          hostAliases:
+          <%- @options[:hostaliases].each do |ip, hostnames| -%>
+          - ip: "<%= ip %>"
+            hostnames:
+            <%- hostnames.each do |hostname| -%>
+            - "<%= hostname %>"
+            <%- end -%>
+          <%- end -%>
+          <%- end -%>
           containers:
           - name: task
             image: <%= @options[:image] %>:<%= @options[:release] %>

--- a/lib/cuber/templates/pod.yml.erb
+++ b/lib/cuber/templates/pod.yml.erb
@@ -8,6 +8,16 @@ metadata:
     app.kubernetes.io/version: <%= @options[:release] %>
     app.kubernetes.io/managed-by: cuber
 spec:
+  <%- if @options[:hostaliases].any? -%>
+  hostAliases:
+  <%- @options[:hostaliases].each do |ip, hostnames| -%>
+  - ip: "<%= ip %>"
+    hostnames:
+    <%- hostnames.each do |hostname| -%>
+    - "<%= hostname %>"
+    <%- end -%>
+  <%- end -%>
+  <%- end -%>
   containers:
   - name: pod-proc
     image: <%= @options[:image] %>:<%= @options[:release] %>


### PR DESCRIPTION
For my use-case of cuber I need to be able to define hostAliases to be able to access some external services by hostname.

Kubernetes provides this functionality: https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/

This PR allows to define multiple hostAliases in your Cuberfile.

Example:
```ruby
app 'test'
repo '.'
dockerfile 'Dockerfile'
dockerconfig 'config/dockerconfig.json'
image 'my/image-name'
hostalias '1.2.3.4', hostnames: ['my-external-service.hostname']
proc :web, 'bundle exec rails s'
```

Maybe you'll find this useful or have any requests for changes.

Thank you again for this amazing gem. 😄