### PR TITLE
Expand Dockerfile path

### DIFF
--- a/lib/cuber/commands/deploy.rb
+++ b/lib/cuber/commands/deploy.rb
@@ -62,7 +62,7 @@ module Cuber::Commands
 
     def build
       print_step 'Building image from Dockerfile'
-      dockerfile = @options[:dockerfile] || 'Dockerfile'
+      dockerfile = File.expand_path(@options[:dockerfile] || 'Dockerfile')
       tag = "#{@options[:image]}:#{@options[:release]}"
       cmd = ['docker', 'build']
       cmd += ['--pull', '--no-cache'] if @options[:cache] == false


### PR DESCRIPTION
With docker-desktop 4.17.0, `docker build` command couldn't resolve the location of Dockerfile.

The execution log is below:

    $ cuber deploy

    -----> Cloning Git repository
    Cloning into '.cuber/repo'...
    remote: Enumerating objects: 140, done.
    remote: Counting objects: 100% (140/140), done.
    remote: Compressing objects: 100% (118/118), done.
    remote: Total 140 (delta 10), reused 113 (delta 8), pack-reused 0
    Receiving objects: 100% (140/140), 47.44 KiB | 319.00 KiB/s, done.
    Resolving deltas: 100% (10/10), done.

    -----> Building image from Dockerfile
    #1 [internal] load build definition from Dockerfile
    #1 transferring dockerfile: 2B done
    #1 DONE 0.0s

    #2 [internal] load .dockerignore
    #2 transferring context: 2B done
    #2 DONE 0.0s
    ERROR: failed to solve: failed to read dockerfile: open /var/lib/docker/tmp/buildkit-mount1598098172/Dockerfile: no such file or directory
    Cuber: docker build failed