### PR TITLE
Only pull images if they are not available locally

### DIFF
--- a/lib/cuber/templates/deployment.yml.erb
+++ b/lib/cuber/templates/deployment.yml.erb
@@ -100,7 +100,7 @@ spec:
       containers:
       - name: migration
         image: <%= @options[:image] %>:<%= @options[:release] %>
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         <%- if @options[:buildpacks] -%>
         command: ["launcher"]
         args: <%= @options[:migrate][:cmd].shellsplit %>
@@ -152,7 +152,7 @@ spec:
       containers:
       - name: <%= procname %>-proc
         image: <%= @options[:image] %>:<%= @options[:release] %>
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         <%- if @options[:buildpacks] -%>
         command: ["launcher"]
         args: <%= proc[:cmd].shellsplit %>
@@ -202,7 +202,7 @@ spec:
       initContainers:
       - name: migration-check
         image: <%= @options[:image] %>:<%= @options[:release] %>
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         <%- if @options[:buildpacks] -%>
         command: ["launcher"]
         args: <%= @options[:migrate][:check].shellsplit %>
@@ -257,7 +257,7 @@ spec:
           containers:
           - name: task
             image: <%= @options[:image] %>:<%= @options[:release] %>
-            imagePullPolicy: Always
+            imagePullPolicy: IfNotPresent
             <%- if @options[:buildpacks] -%>
             command: ["launcher"]
             args: <%= cron[:cmd].shellsplit %>

--- a/lib/cuber/templates/pod.yml.erb
+++ b/lib/cuber/templates/pod.yml.erb
@@ -11,7 +11,7 @@ spec:
   containers:
   - name: pod-proc
     image: <%= @options[:image] %>:<%= @options[:release] %>
-    imagePullPolicy: Always
+    imagePullPolicy: IfNotPresent
     command: ["sleep", "infinity"]
     envFrom:
     - configMapRef:


### PR DESCRIPTION
Avoid excessive downloads and only pull images if needed. This makes the rollout faster and also helps to reduce traffic when cronjobs are used.