### PR TITLE
Add ClusterIP as a service option

### DIFF
--- a/lib/cuber/cuberfile_parser.rb
+++ b/lib/cuber/cuberfile_parser.rb
@@ -19,6 +19,7 @@ module Cuber
       @lb = {}
       @ingress = nil
       @ssl = nil
+      @cluster_ip = nil
     end
 
     def method_missing m, *args
@@ -76,7 +77,7 @@ module Cuber
     def env key, value, secret: false
       secret ? (@secrets[key] = value) : (@env[key] = value)
     end
-    
+
     def health url
       @health = url
     end
@@ -87,6 +88,10 @@ module Cuber
 
     def ingress enabled
       @ingress = enabled
+    end
+
+    def cluster_ip enabled
+      @cluster_ip = enabled
     end
 
     def ssl crt, key

--- a/lib/cuber/cuberfile_validator.rb
+++ b/lib/cuber/cuberfile_validator.rb
@@ -23,6 +23,7 @@ module Cuber
       validate_health
       validate_lb
       validate_ingress
+      validate_cluster_ip
       validate_ssl
       @errors
     end
@@ -119,6 +120,11 @@ module Cuber
     def validate_ingress
       return unless @options[:ingress]
       @errors << 'ingress must be true or false' if @options[:ingress] != true && @options[:ingress] != false
+    end
+
+    def validate_cluster_ip
+      return unless @options[:cluster_ip]
+      @errors << 'cluster_ip must be true or false' if @options[:cluster_ip] != true && @options[:cluster_ip] != false
     end
 
     def validate_ssl

--- a/lib/cuber/templates/deployment.yml.erb
+++ b/lib/cuber/templates/deployment.yml.erb
@@ -377,6 +377,26 @@ spec:
             name: web-service
             port:
               number: 80
+<%- elsif @options[:cluster_ip] -%>
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cluster-ip
+  namespace: <%= @options[:app] %>
+  labels:
+    app.kubernetes.io/name: <%= @options[:app].to_s.to_json %>
+    app.kubernetes.io/instance: <%= @options[:instance].to_s.to_json %>
+    app.kubernetes.io/version: <%= @options[:release].to_s.to_json %>
+    app.kubernetes.io/managed-by: cuber
+spec:
+  type: ClusterIP
+  selector:
+    app: web-proc
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
 <%- else -%>
 ---
 apiVersion: v1


### PR DESCRIPTION
This add an option to create a basic ClusterIP service when deploying with Cuber.

The idea here is to allow for some flexibility in how to expose a Cuber-managed app outside the cluster, but leave that for the user to setup outside of the `Cuberfile`.

In my case in particular I'm deploying my app in a k3s cluster that uses Traefik as the ingress controller and want to use customize the ingress to use host-based routing and cert-manager for SSL certificates.

Thanks for this awesome gem! :smile: It's saved me so much time & complexity compared to other ways of deploying on k8s!