### PR TITLE
Use args instead of command

### DIFF
--- a/lib/cuber/commands/info.rb
+++ b/lib/cuber/commands/info.rb
@@ -68,9 +68,9 @@ module Cuber::Commands
       migration = "migrate-#{@namespace['metadata']['labels']['app.kubernetes.io/instance']}"
       json = kubeget 'job', migration, '--ignore-not-found'
       if json
-        migration_command = json['spec']['template']['spec']['containers'][0]['command'].shelljoin
+        migration_args = json['spec']['template']['spec']['containers'][0]['args'].shelljoin
         migration_status = json['status']['succeeded'].to_i.zero? ? 'Pending' : 'Completed'
-        puts "migrate: #{migration_command} (#{migration_status})"
+        puts "migrate: #{migration_args} (#{migration_status})"
       else
         puts "None detected"
       end
@@ -81,12 +81,12 @@ module Cuber::Commands
       json = kubeget 'deployments'
       json['items'].each do |proc|
         name = proc['metadata']['name']
-        command = proc['spec']['template']['spec']['containers'][0]['command'].shelljoin
+        args = proc['spec']['template']['spec']['containers'][0]['args'].shelljoin
         available = proc['status']['availableReplicas'].to_i
         updated = proc['status']['updatedReplicas'].to_i
         replicas = proc['status']['replicas'].to_i
         scale = proc['spec']['replicas'].to_i
-        puts "#{name}: #{command} (#{available}/#{scale}) #{'OUT-OF-DATE' if replicas - updated > 0}"
+        puts "#{name}: #{args} (#{available}/#{scale}) #{'OUT-OF-DATE' if replicas - updated > 0}"
       end
     end
 
@@ -96,9 +96,9 @@ module Cuber::Commands
       json['items'].each do |cron|
         name = cron['metadata']['name']
         schedule = cron['spec']['schedule']
-        command = cron['spec']['jobTemplate']['spec']['template']['spec']['containers'][0]['command'].shelljoin
+        args = cron['spec']['jobTemplate']['spec']['template']['spec']['containers'][0]['args'].shelljoin
         last = cron['status']['lastScheduleTime']
-        puts "#{name}: #{schedule} #{command} #{'(' + time_ago_in_words(last) + ')' if last}"
+        puts "#{name}: #{schedule} #{args} #{'(' + time_ago_in_words(last) + ')' if last}"
       end
     end
 

--- a/lib/cuber/templates/deployment.yml.erb
+++ b/lib/cuber/templates/deployment.yml.erb
@@ -107,7 +107,7 @@ spec:
         command: ["launcher"]
         args: <%= @options[:migrate][:cmd].shellsplit %>
         <%- else -%>
-        command: <%= @options[:migrate][:cmd].shellsplit %>
+        args: <%= @options[:migrate][:cmd].shellsplit %>
         <%- end -%>
         envFrom:
         - configMapRef:
@@ -159,7 +159,7 @@ spec:
         command: ["launcher"]
         args: <%= proc[:cmd].shellsplit %>
         <%- else -%>
-        command: <%= proc[:cmd].shellsplit %>
+        args: <%= proc[:cmd].shellsplit %>
         <%- end -%>
         resources:
           requests:
@@ -214,7 +214,7 @@ spec:
         command: ["launcher"]
         args: <%= @options[:migrate][:check].shellsplit %>
         <%- else -%>
-        command: <%= @options[:migrate][:check].shellsplit %>
+        args: <%= @options[:migrate][:check].shellsplit %>
         <%- end -%>
         envFrom:
         - configMapRef:


### PR DESCRIPTION
Using args instead of command replaces Docker CMD instead of ENTRYPOINT.

This is counterintuitive, as I found out here: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#define-a-command-and-arguments-when-you-create-a-pod

> The command field corresponds to ENTRYPOINT, and the args field corresponds to CMD in some container runtimes.

In my case it's actually working that way. So if we use args it works fine and doesn't override my ENTRYPOINT, which I assume is normally expected.