### PR TITLE
Allow health checks to be performed on path only

### DIFF
--- a/lib/cuber/cuberfile_validator.rb
+++ b/lib/cuber/cuberfile_validator.rb
@@ -107,7 +107,7 @@ module Cuber
     
     def validate_health
       return unless @options[:health]
-      @errors << 'health checks must be an http url' unless URI.parse(@options[:health]).kind_of? URI::HTTP
+      @errors << 'health checks must be an http url' unless URI.parse(@options[:health]).kind_of? URI::Generic
     end
 
     def validate_lb

--- a/lib/cuber/templates/deployment.yml.erb
+++ b/lib/cuber/templates/deployment.yml.erb
@@ -141,7 +141,7 @@ spec:
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: "25%"
-      maxSurge: 0
+      maxSurge: "25%"
   template:
     metadata:
       labels:
@@ -194,16 +194,20 @@ spec:
           httpGet:
             port: 8080
             path: <%= URI.parse(@options[:health]).path.to_json %>
-            httpHeaders:
-              - name: Host
-                value: <%= URI.parse(@options[:health]).host.to_json %>
-              - name: X-Forwarded-Proto
-                value: <%= URI.parse(@options[:health]).scheme.to_json %>
           initialDelaySeconds: 0
-          periodSeconds: 10
+          periodSeconds: 1
           timeoutSeconds: 5
           successThreshold: 1
           failureThreshold: 3
+        livenessProbe:
+          httpGet:
+            port: 8080
+            path: <%= URI.parse(@options[:health]).path.to_json %>
+          initialDelaySeconds: 5
+        lifecycle:
+          preStop:
+            exec:
+              command: ["sleep", "30"]
         <%- end -%>
       <%- if @options[:migrate] && @options[:migrate][:check] -%>
       initContainers:


### PR DESCRIPTION
And slightly change health checks.

With these settings I managed to get rolling updates that don't lose any requests, while doing 200 concurrent requests.

The liveness probe + the prestop command help finish all the requests before the pod is removed from the load balancer.

Works well for me, let me know if you prefer to keep only parts of this PR, I can split it in two. The local path instead of the full URL is mandatory for me to perform health checks on single pods, I don't know otherwise how you configure your health checks? Can you provide an example? Maybe I can change how I use it instead.